### PR TITLE
Optional random country in FreeProxy.get()

### DIFF
--- a/fp/fp.py
+++ b/fp/fp.py
@@ -9,8 +9,8 @@ import requests
 
 class FreeProxy:
 
-    def __init__(self, country_id=[], timeout=0.5, rand=False, anonym=False):
-        self.country_id = country_id
+    def __init__(self, country_id=None, timeout=0.5, rand=False, anonym=False):
+        self.country_id = [] if country_id is None else country_id
         self.timeout = timeout
         self.random = rand
         self.anonym = anonym

--- a/fp/fp.py
+++ b/fp/fp.py
@@ -40,18 +40,16 @@ class FreeProxy:
             random.shuffle(proxy_list)
             proxy_list = proxy_list
         working_proxy = None
-        while True:
-            for i in range(len(proxy_list)):
-                proxies = {
-                    'http': "http://" + proxy_list[i],
-                }
-                try:
-                    if self.check_if_proxy_is_working(proxies):
-                        working_proxy = self.check_if_proxy_is_working(proxies)
-                        return working_proxy
-                except requests.exceptions.RequestException:
-                    continue
-            break
+        for i in range(len(proxy_list)):
+            proxies = {
+                'http': "http://" + proxy_list[i],
+            }
+            try:
+                if self.check_if_proxy_is_working(proxies):
+                    working_proxy = self.check_if_proxy_is_working(proxies)
+                    return working_proxy
+            except requests.exceptions.RequestException:
+                continue
         if not working_proxy:
             if self.country_id is not None:
                 self.country_id = None

--- a/fp/fp.py
+++ b/fp/fp.py
@@ -55,7 +55,7 @@ class FreeProxy:
                 self.country_id = None
                 return self.get()
             else:
-                return 'There are no working proxies at this time.'
+                raise RuntimeError('There are no working proxies at this time.')
 
     def check_if_proxy_is_working(self, proxies):
         with requests.get('http://www.google.com', proxies=proxies, timeout=self.timeout, stream=True) as r:

--- a/fp/fp.py
+++ b/fp/fp.py
@@ -34,7 +34,7 @@ class FreeProxy:
             print(e)
             sys.exit(1)
 
-    def get(self):
+    def get(self, any_country_on_failure=True):
         proxy_list = self.get_proxy_list()
         if self.random:
             random.shuffle(proxy_list)
@@ -51,7 +51,7 @@ class FreeProxy:
             except requests.exceptions.RequestException:
                 continue
         if not working_proxy:
-            if self.country_id is not None:
+            if any_country_on_failure and self.country_id is not None:
                 self.country_id = None
                 return self.get()
             else:

--- a/test_proxy.py
+++ b/test_proxy.py
@@ -9,14 +9,14 @@ class TestProxy(unittest.TestCase):
     def test_empty_proxy_list(self):
         test = FreeProxy()
         test.get_proxy_list = MagicMock(return_value=[])
-        self.assertEqual(
-            "There are no working proxies at this time.", test.get())
+        with self.assertRaises(RuntimeError):
+            test.get()
 
     def test_invalid_proxy(self):
         test = FreeProxy()
         test.get_proxy_list = MagicMock(return_value=['111.111.11:2222'])
-        self.assertEqual(
-            "There are no working proxies at this time.", test.get())
+        with self.assertRaises(RuntimeError):
+            test.get()
 
     def test_anonym_filter(self):
         test1 = FreeProxy()


### PR DESCRIPTION
It would be useful to be able to choose if a proxy should be chosen from a random country if no working proxy with the user-specified countries could be found. This change is backwards-compatible.

It is also semantically useful to raise an Error when no proxy could be found rather than just returning a string. However, this would break backwards-compatibility.