### PR TITLE
Fixed error with proxy list length < 101 entries

### DIFF
--- a/fp/fp.py
+++ b/fp/fp.py
@@ -22,11 +22,11 @@ class FreeProxy:
             tr_elements = doc.xpath('//*[@id="list"]//tr')
             if not self.country_id:
                 proxies = [f'{tr_elements[i][0].text_content()}:{tr_elements[i][1].text_content()}' for i in
-                           range(1, 101)
+                           range(1, len(tr_elements))
                            if((tr_elements[i][4].text_content()) == 'anonymous' if self.anonym else True)]  # check the 5th column for `anonymous` if needed
             else:
                 proxies = [f'{tr_elements[i][0].text_content()}:{tr_elements[i][1].text_content()}' for i in
-                           range(1, 101)
+                           range(1, len(tr_elements))
                            if tr_elements[i][2].text_content() in self.country_id
                            and ((tr_elements[i][4].text_content()) == 'anonymous' if self.anonym else True)]  # check the 5th column for `anonymous` if needed
             return proxies


### PR DESCRIPTION
The generation of the list of proxies is assuming that the table from https://www.sslproxies.org contains at least 101 entries, which isn't always the case. This pull request uses the length of the table as counter for the loop instead of a fixed length.

This should solve the issue reported as #15 