### PR TITLE
[Issue 35] change google as default by adding customizable url param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.1.3] - 2024-11-07
+
+- Added `url` paramameter
+
 ## [1.1.2] - 2024-07-29
 
 - Updated lxml to version 5.3.0

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ proxy = FreeProxy(url='http://httpbin.org/get').get()
 ## CHANGELOG
 
 ---
-## [1.1.3] - 2024-10-30
+## [1.1.3] - 2024-11-07
 
 - Added `url` paramameter
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ proxy = FreeProxy(url='http://httpbin.org/get').get()
 ## CHANGELOG
 
 ---
+## [1.1.3] - 2024-10-30
+
+- Added `url` paramameter
 
 ## [1.1.2] - 2024-09-07
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ from fp.fp import FreeProxy
 | elite      | bool      | True         | False         |
 | google     | bool,None | False        | None          |
 | https      | bool      | True         | False         |
-
+| url        | str       | ''           | google.com    |
 - **No parameters**
   Get the first working proxy from <https://www.sslproxies.org/>. If no proxies are working, try again pulling from <https://free-proxy-list.net>
 
@@ -126,6 +126,21 @@ proxy = FreeProxy(country_id=['US', 'BR'], timeout=0.3, rand=True).get()
 
 If there are no working proxies with the provided parameters, the script will raise `FreeProxyException` with the message `There are no working proxies at this time.`.
 
+- **`url` parameter**
+  The url parameter allows you to set a custom URL for testing purposes. If left empty, it defaults to 'https://www.google.com'.
+
+Using default URL:
+
+```python
+proxy = FreeProxy().get() 
+```
+
+Using custom URL, if test on different endpoint is needed:
+
+```python
+proxy = FreeProxy(url='http://httpbin.org/get').get() 
+```
+
 ## CHANGELOG
 
 ---
@@ -181,6 +196,10 @@ If there are no working proxies with the provided parameters, the script will ra
 ## [1.0.0] - 2019-02-04
 
 - Initial release
+
+## Disclaimer
+
+The authors of this repository are not responsible for any consequences, damages or losses arising from the use or misuse of this repository or content. Users are solely responsible for their actions and any consequences that may follow.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Free-proxy
 
-![Version 1.1.2](https://img.shields.io/badge/Version-1.1.2-blue.svg)
+![Version 1.1.3](https://img.shields.io/badge/Version-1.1.3-blue.svg)
 
 ## Get free working proxies from <https://www.sslproxies.org/>, <https://www.us-proxy.org/>, <https://free-proxy-list.net/uk-proxy.html> and <https://free-proxy-list.net> and use them in your script
 

--- a/fp/fp.py
+++ b/fp/fp.py
@@ -18,7 +18,7 @@ class FreeProxy:
     working proxy.
     '''
 
-    def __init__(self, country_id=None, timeout=0.5, rand=False, anonym=False, elite=False, google=None, https=False):
+    def __init__(self, country_id=None, timeout=0.5, rand=False, anonym=False, elite=False, google=None, https=False, url='https://www.google.com'):
         self.country_id = country_id
         self.timeout = timeout
         self.random = rand
@@ -26,6 +26,7 @@ class FreeProxy:
         self.elite = elite
         self.google = google
         self.schema = 'https' if https else 'http'
+        self.url = url
 
     def get_proxy_list(self, repeat):
         try:
@@ -87,7 +88,7 @@ class FreeProxy:
             'There are no working proxies at this time.')
 
     def __check_if_proxy_is_working(self, proxies):
-        url = f'{self.schema}://www.google.com'
+        url = f'{self.schema}://{self.url}'
         ip = proxies[self.schema].split(':')[1][2:]
         with requests.get(url, proxies=proxies, timeout=self.timeout, stream=True) as r:
             if r.raw.connection.sock and r.raw.connection.sock.getpeername()[0] == ip:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 setuptools.setup(
     name='free_proxy',
-    version='1.1.2',
+    version='1.1.3',
     author="jundymek",
     author_email="jundymek@gmail.com",
     description="Proxy scraper for further use",

--- a/test_proxy.py
+++ b/test_proxy.py
@@ -118,6 +118,14 @@ class TestProxy(unittest.TestCase):
         actual = subject._FreeProxy__website(repeat=True)
         self.assertEqual('https://free-proxy-list.net', actual)
 
+    def test_default_url(self):
+        proxy =FreeProxy()
+        self.assertEqual(proxy.url, 'https://www.google.com')
+
+    def test_custom_url(self):
+        proxy = FreeProxy(url='http://httpbin.org/get')
+        self.assertEqual(proxy.url, 'http://httpbin.org/get')
+
     def __tr_elements(self):
         return lh.fromstring(
             '<tr>'


### PR DESCRIPTION
This is a proposed change for a suggestion mentioned in Issue #35 
Changes included:
- add new `url` param to address the need for testing proxy on custom endpoint (defaulting to google.com)
- add test cases to check if value is read correctly
- update README: introduce new parameter,  add this item to changelog, add safety disclaimer.