### PR TITLE
Chore/bump deps 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.2.0] - 2026-06-09
+
+- Updated lxml to version 6.1.1
+- Updated requests to version 2.32.5
+- Updated pip-chill to version 1.0.5
+- Pinned minimum dependency versions in `install_requires` (`lxml>=5.0,<7`, `requests>=2.31,<3`)
+- Raised minimum Python version to 3.8
+
 ## [1.1.3] - 2024-11-07
 
 - Added `url` paramameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [1.2.0] - 2026-06-09
 
 - Updated lxml to version 6.1.1
-- Updated requests to version 2.32.5
+- Updated requests to version 2.34.2
 - Updated pip-chill to version 1.0.5
 - Pinned minimum dependency versions in `install_requires` (`lxml>=5.0,<7`, `requests>=2.31,<3`)
 - Raised minimum Python version to 3.8

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Free-proxy
 
-![Version 1.1.3](https://img.shields.io/badge/Version-1.1.3-blue.svg)
+![Version 1.2.0](https://img.shields.io/badge/Version-1.2.0-blue.svg)
 
 ## Get free working proxies from <https://www.sslproxies.org/>, <https://www.us-proxy.org/>, <https://free-proxy-list.net/uk-proxy.html> and <https://free-proxy-list.net> and use them in your script
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-lxml==5.3.0
-pip-chill==1.0.3
-requests==2.32.3
+lxml==6.1.1
+pip-chill==1.0.5
+requests==2.32.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml==6.1.1
 pip-chill==1.0.5
-requests==2.32.5
+requests==2.34.2

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 setuptools.setup(
     name='free_proxy',
-    version='1.1.3',
+    version='1.2.0',
     author="jundymek",
     author_email="jundymek@gmail.com",
     description="Proxy scraper for further use",
@@ -17,6 +17,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
-    install_requires=['lxml', 'requests']
+    python_requires='>=3.8',
+    install_requires=['lxml>=5.0,<7', 'requests>=2.31,<3']
 )


### PR DESCRIPTION
## chore: bump dependencies and release version 1.2.0

### Description

Dependency bump and version release for `free-proxy`. No functional changes to the library — only dependency versions, version pinning, supported Python range, and a security-driven `requests` pin. Last release (1.1.3) was over a year old.

### Changes

- **Dependencies updated:**
  - `lxml` `5.3.0` → `6.1.1`
  - `requests` `2.32.3` → `2.34.2`
  - `pip-chill` `1.0.3` → `1.0.5`
- **Pinned minimum versions** in `install_requires` (previously unbounded `['lxml', 'requests']`): `lxml>=5.0,<7`, `requests>=2.31,<3`. Upper caps protect users from incompatible future major releases (lxml 7 is alpha; requests 3 doesn't exist yet).
- **Raised minimum Python** from `>=3.6` to `>=3.8` (3.6/3.7 are EOL).
- Version bumped to `1.2.0`; `README` badge and `CHANGELOG` updated.

### Security audit

Ran `pip-audit` against the target dependency set — **no known vulnerabilities**.

| Package | Status |
|---|---|
| lxml 6.1.1 | ✅ CVE-2026-41066 (XXE in `iterparse()`) fixed in 6.1.0; library uses `lxml.html.fromstring`, not `iterparse()`, so unaffected regardless |
| requests 2.34.2 | ✅ CVE-2026-25645 (insecure temp file reuse in `extract_zipped_paths()`) fixed in 2.33.0 |
| pip-chill 1.0.5 | ✅ clean |

The `requests` dev pin was lifted to **2.34.2** specifically so the dev/CI environment is free of CVE-2026-25645. `install_requires` is kept deliberately broad (`requests>=2.31,<3`): pip resolves a compatible 2.32.x on Python 3.8/3.9, and automatically pulls the patched 2.33+ on Python 3.10+.

### Why MINOR (1.2.0), not PATCH

Raising the minimum Python version means users on 3.6/3.7 can no longer install the latest release — a user-visible change to the install contract, which per SemVer warrants a MINOR bump.

### Backward compatibility

Library API is unchanged. Verified by fresh `pip install .` resolution:

- **Python 3.8/3.9** → resolves lxml 6.1.1 + requests 2.32.x → works ✅
- **Python 3.10+** → resolves lxml 6.1.1 + requests 2.34.2 (patched) → works ✅
- **Python 3.6/3.7** → can no longer install 1.2.0 (stays on 1.1.3) — intended, hence MINOR.

### Testing

All verification done in isolated, throwaway environments — existing setups untouched.

| Check | Result |
|---|---|
| Full unit suite (17 tests, incl. live network filter tests) — Python 3.9 | ✅ 17/17 |
| Full unit suite — Python 3.11 | ✅ 17/17 |
| Fresh `pip install .` — Python 3.9 | ✅ lxml 6.1.1 + requests 2.32.5, scraping works |
| Fresh `pip install .` — Python 3.11 | ✅ lxml 6.1.1 + requests 2.34.2, scraping works |
| Smoke test from **installed package** (not repo dir) | ✅ scrapes sslproxies + us-proxy |
| All 4 proxy sites parse correctly (HTML structure / column mapping) | ✅ sslproxies.org, us-proxy.org, uk-proxy.html, free-proxy-list.net |
| `pip-audit` on dev env | ✅ no known vulnerabilities |

### Commits

- `cc7d7fc` — chore: bump dependencies and release version 1.2.0
- `f9ec573` — chore: pin requests to patched 2.34.2 (CVE-2026-25645)
