### PR TITLE
fix: remove duplicated URL schema in proxy check (v1.2.1, #52, #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.1] - 2026-06-09
+
+- Fixed proxy check failing due to a duplicated URL schema (`http://https://...`), introduced in 1.1.3. This broke `https=True` and custom `url` usage (#52, #43).
+
 ## [1.2.0] - 2026-06-09
 
 - Updated lxml to version 6.1.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Free-proxy
 
-![Version 1.2.0](https://img.shields.io/badge/Version-1.2.0-blue.svg)
+![Version 1.2.1](https://img.shields.io/badge/Version-1.2.1-blue.svg)
 
 ## Get free working proxies from <https://www.sslproxies.org/>, <https://www.us-proxy.org/>, <https://free-proxy-list.net/uk-proxy.html> and <https://free-proxy-list.net> and use them in your script
 

--- a/fp/fp.py
+++ b/fp/fp.py
@@ -88,7 +88,7 @@ class FreeProxy:
             'There are no working proxies at this time.')
 
     def __check_if_proxy_is_working(self, proxies):
-        url = f'{self.schema}://{self.url}'
+        url = self.url
         ip = proxies[self.schema].split(':')[1][2:]
         with requests.get(url, proxies=proxies, timeout=self.timeout, stream=True) as r:
             if r.raw.connection.sock and r.raw.connection.sock.getpeername()[0] == ip:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 setuptools.setup(
     name='free_proxy',
-    version='1.2.0',
+    version='1.2.1',
     author="jundymek",
     author_email="jundymek@gmail.com",
     description="Proxy scraper for further use",

--- a/test_proxy.py
+++ b/test_proxy.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import lxml.html as lh
 
@@ -125,6 +125,36 @@ class TestProxy(unittest.TestCase):
     def test_custom_url(self):
         proxy = FreeProxy(url='http://httpbin.org/get')
         self.assertEqual(proxy.url, 'http://httpbin.org/get')
+
+    @patch('fp.fp.requests.get')
+    def test_check_uses_default_url_without_double_schema(self, mock_get):
+        '''The default url should be requested as-is, not prefixed with schema again.'''
+        mock_get.return_value.__enter__ = lambda s: s
+        mock_get.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value.raw.connection.sock = None
+        proxy = FreeProxy()
+        proxy.get_proxy_list = MagicMock(return_value=['1.2.3.4:8080'])
+        try:
+            proxy.get()
+        except FreeProxyException:
+            pass
+        requested_url = mock_get.call_args[0][0]
+        self.assertEqual('https://www.google.com', requested_url)
+
+    @patch('fp.fp.requests.get')
+    def test_check_uses_custom_url_without_double_schema(self, mock_get):
+        '''A custom url should be requested as-is, not prefixed with schema again.'''
+        mock_get.return_value.__enter__ = lambda s: s
+        mock_get.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value.raw.connection.sock = None
+        proxy = FreeProxy(url='http://httpbin.org/get')
+        proxy.get_proxy_list = MagicMock(return_value=['1.2.3.4:8080'])
+        try:
+            proxy.get()
+        except FreeProxyException:
+            pass
+        requested_url = mock_get.call_args[0][0]
+        self.assertEqual('http://httpbin.org/get', requested_url)
 
     def __tr_elements(self):
         return lh.fromstring(


### PR DESCRIPTION
## fix: remove duplicated URL schema in proxy check (v1.2.1, #52, #43)

### Problem

Since v1.1.3, `FreeProxy(https=True).get()` and any custom `url=` always failed with `FreeProxyException: There are no working proxies at this time.` — reported in #52 and #43.

### Root cause

In `__check_if_proxy_is_working`, the test URL was built as:

```python
url = f'{self.schema}://{self.url}'
```

But `self.url` already includes a schema (default `'https://www.google.com'`). This produced a malformed double-schema URL:

| Call | URL actually requested |
|---|---|
| `FreeProxy()` | `http://https://www.google.com` ❌ |
| `FreeProxy(https=True)` | `https://https://www.google.com` ❌ |
| `FreeProxy(url='http://httpbin.org/get')` | `http://http://httpbin.org/get` ❌ |

Every proxy check raised on the malformed URL, so `get()` treated all proxies as dead and ultimately raised `FreeProxyException`. Regression introduced in 1.1.3 (#49) when the `url` parameter was added.

### Fix

Use `self.url` directly, since it already carries its schema:

```python
url = self.url
```

### Tests

Added two regression tests (TDD — written first, confirmed failing before the fix):

- `test_check_uses_default_url_without_double_schema`
- `test_check_uses_custom_url_without_double_schema`

| Check | Result |
|---|---|
| Full suite — Python 3.9 | OK 19/19 |
| Full suite — Python 3.11 | OK 19/19 |
| Live `FreeProxy(https=True).get()` (was always failing per #52) | OK returns a working proxy |

### Version

Patch bump `1.2.0` -> `1.2.1` (bugfix, no API change). CHANGELOG and README badge updated.

Closes #52
Closes #43
